### PR TITLE
Improve calculation of expected dynamic symbol string results

### DIFF
--- a/test/ripper_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_parser/commenting_ripper_parser_test.rb
@@ -14,8 +14,19 @@ describe RipperParser::CommentingRipperParser do
 
   describe "handling comments" do
     # Handle different results for dynamic symbol strings. This was changed in
-    # Ruby 2.6.3 and up. See https://bugs.ruby-lang.org/issues/15670
-    let(:dsym_string_type) { RUBY_VERSION < "2.6.3" ? :xstring : :string_content }
+    # Ruby 2.6.3 and up, and backported to 2.5.6 and 2.5.7.
+    # See https://bugs.ruby-lang.org/issues/15670
+    let(:dsym_string_type) do
+      if RUBY_VERSION < "2.5.6"
+        :xstring
+      elsif RUBY_VERSION < "2.6.0"
+        :string_content
+      elsif RUBY_VERSION < "2.6.3"
+        :xstring
+      else
+        :string_content
+      end
+    end
 
     it "produces a comment node surrounding a commented def" do
       result = parse_with_builder "# Foo\ndef foo; end"


### PR DESCRIPTION
This makes the tests pass on Ruby 2.5.6 and 2.5.7.