### PR TITLE
Remove obsolete version checks

### DIFF
--- a/lib/ripper_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_parser/sexp_handlers/blocks.rb
@@ -210,12 +210,7 @@ module RipperParser
       def handle_double_splat(doublesplat)
         return [] unless doublesplat
 
-        # Anonymous kwrest arguments are parsed into an Integer in Ruby 2.4
-        if RUBY_VERSION < "2.5.0" && doublesplat.is_a?(Integer)
-          [s(:dsplat, s(:lvar, :""))]
-        else
-          [s(:dsplat, process(doublesplat))]
-        end
+        [s(:dsplat, process(doublesplat))]
       end
 
       def handle_block_argument(block)

--- a/test/ripper_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_parser/sexp_handlers/assignment_test.rb
@@ -192,31 +192,18 @@ describe RipperParser::Parser do
         end
 
         it "works with a method call with argument without brackets" do
-          expected = if RUBY_VERSION < "2.4.0"
+          expected = s(:lvasgn, :foo,
                        s(:rescue,
-                         s(:lvasgn, :foo, s(:send, nil, :bar, s(:send, nil, :baz))),
-                         s(:resbody, nil, nil, s(:send, nil, :qux)))
-                     else
-                       s(:lvasgn, :foo,
-                         s(:rescue,
-                           s(:send, nil, :bar, s(:send, nil, :baz)),
-                           s(:resbody, nil, nil, s(:send, nil, :qux)), nil))
-                     end
+                         s(:send, nil, :bar, s(:send, nil, :baz)),
+                         s(:resbody, nil, nil, s(:send, nil, :qux)), nil))
           _("foo = bar baz rescue qux").must_be_parsed_as expected
         end
 
         it "works with a class method call with argument without brackets" do
-          expected = if RUBY_VERSION < "2.4.0"
+          expected = s(:lvasgn, :foo,
                        s(:rescue,
-                         s(:lvasgn, :foo,
-                           s(:send, s(:const, nil, :Bar), :baz, s(:send, nil, :qux))),
-                         s(:resbody, nil, nil, s(:send, nil, :quuz)))
-                     else
-                       s(:lvasgn, :foo,
-                         s(:rescue,
-                           s(:send, s(:const, nil, :Bar), :baz, s(:send, nil, :qux)),
-                           s(:resbody, nil, nil, s(:send, nil, :quuz)), nil))
-                     end
+                         s(:send, s(:const, nil, :Bar), :baz, s(:send, nil, :qux)),
+                         s(:resbody, nil, nil, s(:send, nil, :quuz)), nil))
           _("foo = Bar.baz qux rescue quuz")
             .must_be_parsed_as expected
         end


### PR DESCRIPTION
This removes checks for Ruby versions that are no longer supported by
this gem.
