### PR TITLE
Improve Ruby 2.7 support

### DIFF
--- a/lib/ripper_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_parser/sexp_handlers/blocks.rb
@@ -219,8 +219,18 @@ module RipperParser
         [process(block)]
       end
 
+      LVAR_MATCHER = Sexp::Matcher.new(:lvar, Sexp._)
+      NUMBERED_PARAMS = (1..9).map { |it| :"_#{it}" }.freeze
+
       def make_iter_block(call, args, stmt)
+        if args.nil? && RUBY_VERSION >= "2.7.0"
+          lvar_names = (LVAR_MATCHER / stmt).map { |it| it[1] }
+          count = (NUMBERED_PARAMS & lvar_names).length
+          return s(:numblock, call, count, stmt).line(call.line) if count > 0
+        end
+
         args ||= s(:args)
+
         stmt = nil if stmt.empty?
 
         s(:block, call, args, stmt).line(call.line)

--- a/lib/ripper_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_parser/sexp_handlers/blocks.rb
@@ -10,7 +10,7 @@ module RipperParser
         _, args, stmt = block
         call = process(call)
         stmts = stmt.first || s()
-        make_iter call, args, stmts
+        make_iter_block call, args, stmts
       end
 
       def process_brace_block(exp)
@@ -158,7 +158,7 @@ module RipperParser
         call = s(:lambda)
         call.line = line
 
-        make_iter call, args, safe_unwrap_void_stmt(statements)
+        make_iter_lambda call, args, safe_unwrap_void_stmt(statements)
       end
 
       private
@@ -219,11 +219,17 @@ module RipperParser
         [process(block)]
       end
 
-      def make_iter(call, args, stmt)
+      def make_iter_block(call, args, stmt)
         args ||= s(:args)
-        line = call.line || args.line
         stmt = nil if stmt.empty?
-        s(:block, call, args, stmt).line(line)
+
+        s(:block, call, args, stmt).line(call.line)
+      end
+
+      def make_iter_lambda(call, args, stmt)
+        stmt = nil if stmt.empty?
+
+        s(:block, call, args, stmt).line(call.line)
       end
 
       def wrap_in_begin(statements)

--- a/lib/ripper_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_parser/sexp_handlers/conditionals.rb
@@ -83,9 +83,12 @@ module RipperParser
       def process_in(exp)
         _, pattern, truepart, falsepart = exp.shift 4
 
+        falsepart = process(falsepart)
+        falsepart = [nil] if falsepart.nil?
         pattern = handle_pattern(pattern)
+
         s(s(:in_pattern, pattern, nil, process(truepart)),
-          process(falsepart))
+          *falsepart)
       end
 
       def process_else(exp)

--- a/lib/ripper_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_parser/sexp_handlers/conditionals.rb
@@ -103,6 +103,15 @@ module RipperParser
         s(:array_pattern, *elements)
       end
 
+      def process_hshptn(exp)
+        _, _, body, = exp.shift 4
+
+        elements = body.map do |key, value|
+          s(:pair, process(key), handle_pattern(value))
+        end
+        s(:hash_pattern, *elements)
+      end
+
       private
 
       def handle_condition(cond)

--- a/test/ripper_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_parser/sexp_handlers/blocks_test.rb
@@ -214,6 +214,33 @@ describe RipperParser::Parser do
                                s(:send, nil, :qux,
                                  s(:lvar, :bar)))
       end
+
+      it "works with numbered parameters" do
+        if RUBY_VERSION < "2.7.0"
+          skip "This Ruby version does not support numbered parameters"
+        end
+        _("foo { bar _1, _2 }")
+          .must_be_parsed_as s(:numblock,
+                               s(:send, nil, :foo), 2,
+                               s(:send, nil, :bar,
+                                 s(:lvar, :_1),
+                                 s(:lvar, :_2)))
+      end
+
+      it "parser code that looks numbered parameters correctly on older rubies" do
+        if RUBY_VERSION > "2.7.0"
+          skip "This Ruby version interprets this code as numbered parameters"
+        end
+        _("_1 = 1; foo { bar _1, _2 }")
+          .must_be_parsed_as s(:begin,
+                               s(:lvasgn, :_1, s(:int, 1)),
+                               s(:block,
+                                 s(:send, nil, :foo),
+                                 s(:args),
+                                 s(:send, nil, :bar,
+                                   s(:lvar, :_1),
+                                   s(:send, nil, :_2))))
+      end
     end
 
     describe "for begin" do

--- a/test/ripper_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_parser/sexp_handlers/conditionals_test.rb
@@ -568,6 +568,20 @@ describe RipperParser::Parser do
                                    s(:lvar, :bar))), nil)
       end
 
+      it "works with a multiple in clauses" do
+        _("case foo; in [\"a\"]; bar; in qux; quuz qux; end")
+          .must_be_parsed_as s(:case_match,
+                               s(:send, nil, :foo),
+                               s(:in_pattern,
+                                 s(:array_pattern,
+                                   s(:str, "a")), nil,
+                                 s(:send, nil, :bar)),
+                               s(:in_pattern,
+                                 s(:match_var, :qux), nil,
+                                 s(:send, nil, :quuz,
+                                   s(:lvar, :qux))), nil)
+      end
+
       it "works with an in clause for array matching" do
         _("case foo; in [bar, baz]; qux bar, baz; end")
           .must_be_parsed_as s(:case_match,

--- a/test/ripper_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_parser/sexp_handlers/conditionals_test.rb
@@ -594,6 +594,19 @@ describe RipperParser::Parser do
                                    s(:lvar, :bar),
                                    s(:lvar, :baz))), nil)
       end
+
+      it "works with an in clause for hash matching" do
+        _("case foo; in { bar: baz }; qux baz; end")
+          .must_be_parsed_as s(:case_match,
+                               s(:send, nil, :foo),
+                               s(:in_pattern,
+                                 s(:hash_pattern,
+                                   s(:pair,
+                                     s(:sym, :bar),
+                                     s(:match_var, :baz))), nil,
+                                 s(:send, nil, :qux,
+                                   s(:lvar, :baz))), nil)
+      end
     end
   end
 end

--- a/test/ripper_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_parser/sexp_handlers/conditionals_test.rb
@@ -430,7 +430,7 @@ describe RipperParser::Parser do
       end
     end
 
-    describe "for case block" do
+    describe "for case block with when clauses" do
       it "works with a single when clause" do
         _("case foo; when bar; baz; end")
           .must_be_parsed_as s(:case,
@@ -550,6 +550,35 @@ describe RipperParser::Parser do
                                s(:kwbegin,
                                  s(:send, nil, :qux),
                                  s(:send, nil, :quuz)))
+      end
+    end
+
+    describe "for a case block with in clauses" do
+      before do
+        skip "This Ruby version does not support pattern matching" if RUBY_VERSION < "2.7.0"
+      end
+
+      it "works with a single in clause" do
+        _("case foo; in bar; qux bar; end")
+          .must_be_parsed_as s(:case_match,
+                               s(:send, nil, :foo),
+                               s(:in_pattern,
+                                 s(:match_var, :bar), nil,
+                                 s(:send, nil, :qux,
+                                   s(:lvar, :bar))), nil)
+      end
+
+      it "works with an in clause for array matching" do
+        _("case foo; in [bar, baz]; qux bar, baz; end")
+          .must_be_parsed_as s(:case_match,
+                               s(:send, nil, :foo),
+                               s(:in_pattern,
+                                 s(:array_pattern,
+                                   s(:match_var, :bar),
+                                   s(:match_var, :baz)), nil,
+                                 s(:send, nil, :qux,
+                                   s(:lvar, :bar),
+                                   s(:lvar, :baz))), nil)
       end
     end
   end

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -4,3 +4,8 @@
 ..1
 foo = 2; # Extra ; needed here: https://github.com/whitequark/parser/issues/814
 ..foo
+
+# Argument forwarding
+def bar(...)
+  qux(...)
+end

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -9,3 +9,9 @@ foo = 2; # Extra ; needed here: https://github.com/whitequark/parser/issues/814
 def bar(...)
   qux(...)
 end
+
+# Pattern matching (experimental)
+case foo
+  in [bar, baz]
+  quz = bar + baz
+end

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -27,3 +27,8 @@ case foo
   in blub
   p blub
 end
+
+case foo
+  in { bar: [baz, qux] }
+  quz = bar(baz) + baz
+end

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -12,6 +12,11 @@ end
 
 # Pattern matching (experimental)
 case foo
+  in blub
+  p blub
+end
+
+case foo
   in [bar, baz]
   quz = bar + baz
 end

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -32,3 +32,6 @@ case foo
   in { bar: [baz, qux] }
   quz = bar(baz) + baz
 end
+
+# Numbered parameters (experimental)
+[1, 2, 3].each { foo _1 }

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -20,3 +20,10 @@ case foo
   in [bar, baz]
   quz = bar + baz
 end
+
+case foo
+  in [bar, baz]
+  quz = bar + baz
+  in blub
+  p blub
+end


### PR DESCRIPTION
- Add sample of argument forwarding
- Add sample of pattern matching
- Handle case blocks with lvar and array pattern matching
- Handle case with multiple pattern matching clauses
- Handle case with hash pattern matching
- Split and simplify make_iter implementation
- Support numbered block parameters
