### PR TITLE
Update compatibility to match most recent AST format

### DIFF
--- a/lib/ripper_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_parser/sexp_handlers/blocks.rb
@@ -56,7 +56,9 @@ module RipperParser
         when 1
           child = args.sexp_body.first
           case child.sexp_type
-          when :arg, :mlhs
+          when :arg
+            args.sexp_body = [s(:procarg0, child)]
+          when :mlhs
             child.sexp_type = :procarg0
           end
         when 2

--- a/lib/ripper_parser/sexp_handlers/method_calls.rb
+++ b/lib/ripper_parser/sexp_handlers/method_calls.rb
@@ -37,7 +37,7 @@ module RipperParser
       # Handle implied hashes, such as at the end of argument lists.
       def process_bare_assoc_hash(exp)
         _, elems = exp.shift 2
-        s(:hash, *map_process_list(elems))
+        s(:kwargs, *map_process_list(elems))
       end
 
       CALL_OP_MAP = {

--- a/lib/ripper_parser/sexp_handlers/methods.rb
+++ b/lib/ripper_parser/sexp_handlers/methods.rb
@@ -76,7 +76,7 @@ module RipperParser
       }.freeze
 
       def convert_special_args(args)
-        return s(:forward_args) if args.sexp_body.first == s(:args_forward)
+        return s(:args, s(:forward_arg)) if args.sexp_body.first == s(:args_forward)
 
         args.line ||= args.sexp_body.first&.line
         args.sexp_body = args.sexp_body.map { |item| convert_argument item }

--- a/test/ripper_parser/parser_test.rb
+++ b/test/ripper_parser/parser_test.rb
@@ -92,10 +92,10 @@ describe RipperParser::Parser do
                                  s(:send, nil, :bar)))
       end
 
-      it "works for a bare hash" do
+      it "works for keyword arguments" do
         _("foo bar => baz")
           .must_be_parsed_as s(:send, nil, :foo,
-                               s(:hash,
+                               s(:kwargs,
                                  s(:pair,
                                    s(:send, nil, :bar),
                                    s(:send, nil, :baz))))

--- a/test/ripper_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_parser/sexp_handlers/blocks_test.rb
@@ -118,7 +118,7 @@ describe RipperParser::Parser do
         _("foo do |bar|; end")
           .must_be_parsed_as s(:block,
                                s(:send, nil, :foo),
-                               s(:args, s(:procarg0, :bar)), nil)
+                               s(:args, s(:procarg0, s(:arg, :bar))), nil)
       end
 
       it "works with multiple arguments" do
@@ -764,7 +764,7 @@ describe RipperParser::Parser do
           .must_be_parsed_as s(:block,
                                s(:send, nil, :lambda),
                                s(:args,
-                                 s(:procarg0, :foo)),
+                                 s(:procarg0, s(:arg, :foo))),
                                s(:send, nil, :bar))
       end
 

--- a/test/ripper_parser/sexp_handlers/method_calls_test.rb
+++ b/test/ripper_parser/sexp_handlers/method_calls_test.rb
@@ -67,7 +67,7 @@ describe RipperParser::Parser do
                                  nil,
                                  :foo,
                                  s(:send, nil, :bar),
-                                 s(:hash,
+                                 s(:kwargs,
                                    s(:pair,
                                      s(:sym, :baz), s(:send, nil, :qux))))
         end
@@ -78,7 +78,7 @@ describe RipperParser::Parser do
                                  nil,
                                  :foo,
                                  s(:send, nil, :bar),
-                                 s(:hash,
+                                 s(:kwargs,
                                    s(:pair, s(:sym, :baz), s(:send, nil, :qux)),
                                    s(:pair, s(:sym, :quux), s(:send, nil, :quuz))))
         end
@@ -89,7 +89,7 @@ describe RipperParser::Parser do
                                  nil,
                                  :foo,
                                  s(:send, nil, :bar),
-                                 s(:hash,
+                                 s(:kwargs,
                                    s(:kwsplat, s(:send, nil, :baz))))
         end
 
@@ -99,7 +99,7 @@ describe RipperParser::Parser do
                                  nil,
                                  :foo,
                                  s(:send, nil, :bar),
-                                 s(:hash,
+                                 s(:kwargs,
                                    s(:pair, s(:sym, :baz), s(:send, nil, :qux)),
                                    s(:kwsplat, s(:send, nil, :quuz))))
         end

--- a/test/ripper_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_parser/sexp_handlers/methods_test.rb
@@ -235,7 +235,7 @@ describe RipperParser::Parser do
         end
         _("def foo(...); bar(...); end")
           .must_be_parsed_as s(:def, :foo,
-                               s(:forward_args),
+                               s(:args, s(:forward_arg)),
                                s(:send, nil, :bar,
                                  s(:forwarded_args)))
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,10 +13,11 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
 require "ripper_parser"
 require "parser/current"
-Parser::Builders::Default.emit_lambda   = true
-Parser::Builders::Default.emit_procarg0 = true
-Parser::Builders::Default.emit_encoding = true
-Parser::Builders::Default.emit_index    = true
+Parser::Builders::Default.emit_lambda              = true
+Parser::Builders::Default.emit_procarg0            = true
+Parser::Builders::Default.emit_encoding            = true
+Parser::Builders::Default.emit_index               = true
+Parser::Builders::Default.emit_arg_inside_procarg0 = true
 
 module MiniTest
   class Spec

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ Parser::Builders::Default.emit_procarg0            = true
 Parser::Builders::Default.emit_encoding            = true
 Parser::Builders::Default.emit_index               = true
 Parser::Builders::Default.emit_arg_inside_procarg0 = true
+Parser::Builders::Default.emit_forward_arg         = true
 
 module MiniTest
   class Spec

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,7 @@ Parser::Builders::Default.emit_index               = true
 Parser::Builders::Default.emit_arg_inside_procarg0 = true
 Parser::Builders::Default.emit_forward_arg         = true
 Parser::Builders::Default.emit_kwargs              = true
+Parser::Builders::Default.emit_match_pattern       = true
 
 module MiniTest
   class Spec

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ Parser::Builders::Default.emit_encoding            = true
 Parser::Builders::Default.emit_index               = true
 Parser::Builders::Default.emit_arg_inside_procarg0 = true
 Parser::Builders::Default.emit_forward_arg         = true
+Parser::Builders::Default.emit_kwargs              = true
 
 module MiniTest
   class Spec


### PR DESCRIPTION
- Update results to match opting into emit_arg_inside_procarg0
- Update results to match opting into emit_forward_arg
- Update results to match opting into emit_kwargs
- Set emit_match_pattern option for comparison tests
