### PR TITLE
Honor encoding comments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 25
+  Max: 26
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
@@ -24,7 +24,7 @@ Metrics/MethodLength:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 202
+  Max: 203
 
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,7 +24,7 @@ Metrics/MethodLength:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 201
+  Max: 202
 
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ advanced location information and rewriting, use Parser!
 * Produces Sexp objects with the same structure as Parser's AST::Node results
 * Does not produce compatible location data
 * Does not produce compatible comment data
-* Accepts some non-UTF8 compatible string literals, which are rejected by Parser
 
 ## Install
 

--- a/lib/ripper_parser/sexp_handlers/string_literals.rb
+++ b/lib/ripper_parser/sexp_handlers/string_literals.rb
@@ -224,19 +224,18 @@ module RipperParser
       end
 
       def perform_unescapes(content, delim)
-        old_encoding = content.encoding
         content.gsub!(/\r\n/, "\n")
         case delim
         when NON_INTERPOLATING_HEREDOC
           content
         when INTERPOLATING_HEREDOC, *INTERPOLATING_STRINGS, INTERPOLATING_WORD_LIST
-          fix_encoding unescape(content), old_encoding
+          unescape(content)
         when *NON_INTERPOLATING_STRINGS
-          fix_encoding simple_unescape(content, delim), old_encoding
+          simple_unescape(content, delim)
         when *REGEXP_LITERALS
-          fix_encoding unescape_regexp(content), old_encoding
+          unescape_regexp(content)
         when NON_INTERPOLATING_WORD_LIST
-          fix_encoding simple_unescape_wordlist_word(content, delim), old_encoding
+          simple_unescape_wordlist_word(content, delim)
         end
       end
     end

--- a/lib/ripper_parser/sexp_handlers/string_literals.rb
+++ b/lib/ripper_parser/sexp_handlers/string_literals.rb
@@ -225,18 +225,21 @@ module RipperParser
 
       def perform_unescapes(content, delim)
         content.gsub!(/\r\n/, "\n")
-        case delim
-        when NON_INTERPOLATING_HEREDOC
-          content
-        when INTERPOLATING_HEREDOC, *INTERPOLATING_STRINGS, INTERPOLATING_WORD_LIST
-          unescape(content)
-        when *NON_INTERPOLATING_STRINGS
-          simple_unescape(content, delim)
-        when *REGEXP_LITERALS
-          unescape_regexp(content)
-        when NON_INTERPOLATING_WORD_LIST
-          simple_unescape_wordlist_word(content, delim)
-        end
+        result = case delim
+                 when NON_INTERPOLATING_HEREDOC
+                   content
+                 when INTERPOLATING_HEREDOC, *INTERPOLATING_STRINGS, INTERPOLATING_WORD_LIST
+                   unescape(content)
+                 when *NON_INTERPOLATING_STRINGS
+                   simple_unescape(content, delim)
+                 when *REGEXP_LITERALS
+                   unescape_regexp(content)
+                 when NON_INTERPOLATING_WORD_LIST
+                   simple_unescape_wordlist_word(content, delim)
+                 end
+        raise SyntaxError unless result.valid_encoding?
+
+        result
       end
     end
   end

--- a/lib/ripper_parser/sexp_handlers/string_literals.rb
+++ b/lib/ripper_parser/sexp_handlers/string_literals.rb
@@ -125,7 +125,7 @@ module RipperParser
                   [content]
                 else
                   if /\n/.match?(content)
-                    content.split(/(\n)/).each_slice(2).map { |*it| it.join }
+                    content.split(/(\n)/).each_slice(2).map(&:join)
                   else
                     [content]
                   end
@@ -224,18 +224,19 @@ module RipperParser
       end
 
       def perform_unescapes(content, delim)
+        old_encoding = content.encoding
         content.gsub!(/\r\n/, "\n")
         case delim
         when NON_INTERPOLATING_HEREDOC
           content
         when INTERPOLATING_HEREDOC, *INTERPOLATING_STRINGS, INTERPOLATING_WORD_LIST
-          fix_encoding unescape(content)
+          fix_encoding unescape(content), old_encoding
         when *NON_INTERPOLATING_STRINGS
-          fix_encoding simple_unescape(content, delim)
+          fix_encoding simple_unescape(content, delim), old_encoding
         when *REGEXP_LITERALS
-          fix_encoding unescape_regexp(content)
+          fix_encoding unescape_regexp(content), old_encoding
         when NON_INTERPOLATING_WORD_LIST
-          fix_encoding simple_unescape_wordlist_word(content, delim)
+          fix_encoding simple_unescape_wordlist_word(content, delim), old_encoding
         end
       end
     end

--- a/lib/ripper_parser/unescape.rb
+++ b/lib/ripper_parser/unescape.rb
@@ -91,14 +91,6 @@ module RipperParser
       end
     end
 
-    def fix_encoding(string, encoding)
-      unless string.encoding == encoding
-        dup = string.dup.force_encoding encoding
-        return dup if dup.valid_encoding?
-      end
-      string
-    end
-
     def unescape_regexp(string)
       string.gsub(/\\\\/) do
         "\\\\"
@@ -124,7 +116,7 @@ module RipperParser
       when /^(M-\\C-|C-\\M-|M-\\c|c\\M-).$/
         meta(control(bare[-1].ord)).chr
       when /^[0-7]+/
-        bare.to_i(8).chr
+        bare.to_i(8).chr.force_encoding(bare.encoding)
       else
         bare
       end
@@ -135,7 +127,7 @@ module RipperParser
     end
 
     def hex_to_char(str)
-      str.to_i(16).chr
+      str.to_i(16).chr.force_encoding(str.encoding)
     end
 
     def control(val)

--- a/lib/ripper_parser/unescape.rb
+++ b/lib/ripper_parser/unescape.rb
@@ -91,9 +91,9 @@ module RipperParser
       end
     end
 
-    def fix_encoding(string)
-      unless string.encoding == Encoding::UTF_8
-        dup = string.dup.force_encoding Encoding::UTF_8
+    def fix_encoding(string, encoding)
+      unless string.encoding == encoding
+        dup = string.dup.force_encoding encoding
         return dup if dup.valid_encoding?
       end
       string

--- a/test/ripper_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_parser/sexp_handlers/string_literals_test.rb
@@ -228,6 +228,11 @@ describe RipperParser::Parser do
           .must_be_parsed_as s(:str, "bar\rbaz\n")
       end
 
+      it "honors encoding comments" do
+        _("# encoding: ascii-8bit\n\"\\0\"")
+          .must_be_parsed_as s(:str, (+"\x00").force_encoding("ASCII-8BIT"))
+      end
+
       describe "with double-quoted strings with escape sequences" do
         it "works for strings with escape sequences" do
           _('"\\n"')

--- a/test/ripper_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_parser/sexp_handlers/string_literals_test.rb
@@ -233,6 +233,11 @@ describe RipperParser::Parser do
           .must_be_parsed_as s(:str, (+"\x00").force_encoding("ASCII-8BIT"))
       end
 
+      it "switches to UTF8 if multi-byte escapes are used" do
+        _("# encoding: ascii-8bit\n\"\\u00a4\"")
+          .must_be_parsed_as s(:str, "\u00a4")
+      end
+
       describe "with double-quoted strings with escape sequences" do
         it "works for strings with escape sequences" do
           _('"\\n"')
@@ -318,14 +323,19 @@ describe RipperParser::Parser do
           _('"foo\\u{10FFFF}bar"').must_be_parsed_as s(:str, "foo\u{10FFFF}bar")
         end
 
-        it "converts to unicode if possible" do
+        it "converts octal escapes to unicode if possible" do
           _('"2\302\275"').must_be_parsed_as s(:str, "2½")
         end
 
+        it "converts hex escapes to unicode if possible" do
+          _('"\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E"').must_be_parsed_as s(:str, "日本語")
+        end
+
         # TODO: Raise error instead
-        it "does not convert to unicode if result is not valid" do
+        it "converts to unicode even if result is not valid" do
           bytes = ["2".ord, 0x82, 0o302, 0o275]
           string = bytes.pack("c4")
+          string.force_encoding("UTF-8")
           _('"2\x82\302\275"')
             .must_be_parsed_as s(:str, string)
         end

--- a/test/ripper_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_parser/sexp_handlers/string_literals_test.rb
@@ -331,13 +331,9 @@ describe RipperParser::Parser do
           _('"\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E"').must_be_parsed_as s(:str, "日本語")
         end
 
-        # TODO: Raise error instead
-        it "converts to unicode even if result is not valid" do
-          bytes = ["2".ord, 0x82, 0o302, 0o275]
-          string = bytes.pack("c4")
-          string.force_encoding("UTF-8")
-          _('"2\x82\302\275"')
-            .must_be_parsed_as s(:str, string)
+        it "raises an error if resulting string literal encoding" do
+          parser = RipperParser::Parser.new
+          _(proc { parser.parse '"2\x82\302\275"' }).must_raise RipperParser::SyntaxError
         end
       end
 

--- a/test/samples/ascii.rb
+++ b/test/samples/ascii.rb
@@ -2,3 +2,5 @@
 # frozen_string_literal: true
 
 %Q[foo\n\0\nbar]
+
+"\u00a4"

--- a/test/samples/ascii.rb
+++ b/test/samples/ascii.rb
@@ -1,0 +1,4 @@
+# encoding: ascii-8bit
+# frozen_string_literal: true
+
+%Q[foo\n\0\nbar]


### PR DESCRIPTION
This fixes the encoding of string literals when parsing a file with a non-utf8 encoding comment.

It also changes the behavior for string literals that result in an invalid encoding: Before, these literals were accepted. After this change, RipperParser raises an error, just like Parser.