### PR TITLE
Only dedent first string literal on each line of a heredoc

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 243
+  Max: 254
 
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:

--- a/lib/ripper_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_parser/commenting_ripper_parser.rb
@@ -101,6 +101,18 @@ module RipperParser
       @delimiter_stack.push delimiter
     end
 
+    def on_heredoc_dedent(val, width)
+      next_dedent = true
+      val.map! do |e|
+        if e.is_a?(Array) && e[0] == :@tstring_content
+          e = dedent_element(e, width) if next_dedent
+          next_dedent = e[1].end_with? "\n"
+        end
+        e
+      end
+      val
+    end
+
     def on_heredoc_end(_delimiter)
       @delimiter_stack.pop
     end

--- a/test/ripper_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_parser/commenting_ripper_parser_test.rb
@@ -171,6 +171,19 @@ describe RipperParser::CommentingRipperParser do
                                      s(:stmts, s(:void_stmt, s(4, 10))), nil, nil, nil),
                                    s(4, 0)))))
     end
+
+    it "handles interpolation with subsequent whitespace for dedented heredocs" do
+      result = parse_with_builder "<<~FOO\n  \#{bar} baz\nFOO"
+      _(result).must_equal s(:program,
+                             s(:stmts,
+                               s(:string_literal,
+                                 s(:string_content,
+                                   s(:@tstring_content, "", s(2, 2), "<<~FOO"),
+                                   s(:string_embexpr,
+                                     s(:stmts,
+                                       s(:vcall, s(:@ident, "bar", s(2, 4))))),
+                                   s(:@tstring_content, " baz\n", s(2, 8), "<<~FOO")))))
+    end
   end
 
   describe "handling syntax errors" do

--- a/test/ripper_parser/sexp_handlers/string_literals_test.rb
+++ b/test/ripper_parser/sexp_handlers/string_literals_test.rb
@@ -831,13 +831,22 @@ describe RipperParser::Parser do
             .must_be_parsed_as s(:str, "bar\\tbaz\n")
         end
 
-        it "handles interpolation after a literal part when dedenting" do
+        it "handles interpolation after a literal part" do
           _("<<~FOO\n  foo\n  \#{bar}\nFOO")
             .must_be_parsed_as s(:dstr,
                                  s(:str, "foo\n"),
                                  s(:begin,
                                    s(:send, nil, :bar)),
                                  s(:str, "\n"))
+        end
+
+        it "handles interpolation with subsequent whitespace" do
+          _("<<~FOO\n  \#{bar} baz\nFOO")
+            .must_be_parsed_as s(:dstr,
+                                 s(:str, ""),
+                                 s(:begin,
+                                   s(:send, nil, :bar)),
+                                 s(:str, " baz\n"))
         end
       end
     end


### PR DESCRIPTION
This fixes incorrect parsing for cases like the following:

```ruby
<<~FOO
  #{foo} bar
FOO
```

In this case, the space before 'bar' would be removed. This is a bug in Ripper, but by overriding Ripper::SexpBuilder's `#on_heredoc_dedent` method it can be fixed.
