### PR TITLE
Improve Ruby 2.7 pattern matching handling

### DIFF
--- a/lib/ripper_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_parser/sexp_handlers/conditionals.rb
@@ -121,7 +121,11 @@ module RipperParser
         _, _, body, = exp.shift 4
 
         elements = body.map do |key, value|
-          s(:pair, process(key), handle_pattern(value))
+          if value
+            s(:pair, process(key), handle_pattern(value))
+          else
+            handle_pattern(key)
+          end
         end
         s(:hash_pattern, *elements)
       end
@@ -148,7 +152,13 @@ module RipperParser
 
       def handle_pattern(exp)
         pattern = process(exp)
-        pattern.sexp_type = :match_var if pattern.sexp_type == :lvar
+        case pattern.sexp_type
+        when :lvar
+          pattern.sexp_type = :match_var
+        when :sym
+          @local_variables << pattern[1]
+          pattern.sexp_type = :match_var
+        end
         pattern
       end
     end

--- a/lib/ripper_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_parser/sexp_handlers/conditionals.rb
@@ -111,9 +111,13 @@ module RipperParser
       end
 
       def process_aryptn(exp)
-        _, _, body, = exp.shift 5
+        _, _, body, rest, = exp.shift 5
 
         elements = body.map { |it| handle_pattern(it) }
+        if rest
+          rest = s(:match_rest, handle_pattern(rest))
+          elements << rest
+        end
         s(:array_pattern, *elements)
       end
 
@@ -153,9 +157,7 @@ module RipperParser
       def handle_pattern(exp)
         pattern = process(exp)
         case pattern.sexp_type
-        when :lvar
-          pattern.sexp_type = :match_var
-        when :sym
+        when :lvar, :sym
           @local_variables << pattern[1]
           pattern.sexp_type = :match_var
         end

--- a/lib/ripper_parser/sexp_handlers/operators.rb
+++ b/lib/ripper_parser/sexp_handlers/operators.rb
@@ -22,6 +22,8 @@ module RipperParser
           make_regexp_match_operator(left, right)
         elsif (mapped = BINARY_OPERATOR_MAP[op])
           make_boolean_operator(mapped, left, right)
+        elsif op == :"=>"
+          s(:match_as, handle_pattern(left), handle_pattern(right))
         else
           s(:send, process(left), op, process(right))
         end

--- a/test/ripper_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_parser/sexp_handlers/conditionals_test.rb
@@ -634,6 +634,23 @@ describe RipperParser::Parser do
                    end
         _("1 in foo").must_be_parsed_as expected
       end
+
+      it "works for secondary assignment of matched expression" do
+        expected = if RUBY_VERSION < "3.0.0"
+                     s(:match_pattern,
+                       s(:int, 1),
+                       s(:match_as,
+                         s(:match_var, :foo),
+                         s(:match_var, :bar)))
+                   else
+                     s(:match_pattern_p,
+                       s(:int, 1),
+                       s(:match_as,
+                         s(:match_var, :foo),
+                         s(:match_var, :bar)))
+                   end
+        _("1 in foo => bar").must_be_parsed_as expected
+      end
     end
   end
 end

--- a/test/ripper_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_parser/sexp_handlers/conditionals_test.rb
@@ -603,6 +603,19 @@ describe RipperParser::Parser do
                                    s(:lvar, :baz))), nil)
       end
 
+      it "works with an in clause with rest argument" do
+        _("case foo; in bar, *baz; qux bar, baz; end")
+          .must_be_parsed_as s(:case_match,
+                               s(:send, nil, :foo),
+                               s(:in_pattern,
+                                 s(:array_pattern,
+                                   s(:match_var, :bar),
+                                   s(:match_rest, s(:match_var, :baz))), nil,
+                                 s(:send, nil, :qux,
+                                   s(:lvar, :bar),
+                                   s(:lvar, :baz))), nil)
+      end
+
       it "works with an in clause for hash matching" do
         _("case foo; in { bar: baz }; qux baz; end")
           .must_be_parsed_as s(:case_match,

--- a/test/ripper_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_parser/sexp_handlers/conditionals_test.rb
@@ -615,6 +615,17 @@ describe RipperParser::Parser do
                                  s(:send, nil, :qux,
                                    s(:lvar, :baz))), nil)
       end
+
+      it "works with an in clause for abbreviated hash matching" do
+        _("case foo; in { bar: }; baz bar; end")
+          .must_be_parsed_as s(:case_match,
+                               s(:send, nil, :foo),
+                               s(:in_pattern,
+                                 s(:hash_pattern, s(:match_var, :bar)),
+                                 nil,
+                                 s(:send, nil, :baz, s(:lvar, :bar))),
+                               nil)
+      end
     end
 
     describe "for one-line pattern matching" do

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -36,6 +36,7 @@ end
 
 # One-line pattern matching (experimental)
 1 in foo
+1 in foo => bar
 
 # Numbered parameters (experimental)
 [1, 2, 3].each { foo _1 }

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -14,24 +14,29 @@ end
 # Pattern matching (experimental)
 case foo
   in blub
-  p blub
+    p blub
 end
 
 case foo
   in [bar, baz]
-  quz = bar + baz
+    quz = bar + baz
 end
 
 case foo
   in [bar, baz]
-  quz = bar + baz
+    quz = bar + baz
   in blub
-  p blub
+    p blub
 end
 
 case foo
   in { bar: [baz, qux] }
-  quz = bar(baz) + baz
+    quz = bar(baz) + baz
+end
+
+case { foo: 1, bar: 2 }
+  in { bar: }
+    baz bar
 end
 
 # One-line pattern matching (experimental)

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -39,6 +39,10 @@ case { foo: 1, bar: 2 }
     baz bar
 end
 
+case foo
+  in bar, *baz then quz(bar, baz)
+end
+
 # One-line pattern matching (experimental)
 1 in foo
 1 in foo => bar


### PR DESCRIPTION
- Handle foo in bar => baz construction
- Handle abbreviated matching of hashes in pattern matching
- Handle rest arguments in pattern matching
