### PR TITLE
Update RuboCop and its configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,10 @@ AllCops:
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/ripper_parser.gemspec
+++ b/ripper_parser.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "parser", "~> 3.1.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.32"
   spec.add_development_dependency "rubocop-minitest", "~> 0.20.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
- Bump RuboCop version to support LineContinuationLeadingSpace config
- Configure LineContinuationLeadingSpace cop
