### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,8 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7.0", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7.0", "2.7.2", "2.7.3", "2.7", "3.0", "3.1", "3.2"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.6.0", "2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7.0", "2.7", "3.0", "3.1", "3.2"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
   Exclude:
     - 'test/samples/*'
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/lib/ripper_parser/sexp_handlers/blocks.rb
+++ b/lib/ripper_parser/sexp_handlers/blocks.rb
@@ -240,7 +240,7 @@ module RipperParser
       NUMBERED_PARAMS = (1..9).map { |it| :"_#{it}" }.freeze
 
       def make_iter(call, args, stmt)
-        if args.sexp_body.empty? && RUBY_VERSION >= "2.7.0"
+        if args.sexp_body.empty?
           lvar_names = (LVAR_MATCHER / stmt).map { |it| it[1] }
           count = (NUMBERED_PARAMS & lvar_names).length
           return s(:numblock, call, count, stmt).line(call.line) if count > 0

--- a/ripper_parser.gemspec
+++ b/ripper_parser.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "http://www.github.com/mvz/ripper_parser"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ripper_parser"

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -6,8 +6,6 @@ describe "Using RipperParser and Parser" do
   make_my_diffs_pretty!
 
   Dir.glob(File.expand_path("../samples/*.rb", File.dirname(__FILE__))).each do |file|
-    next if RUBY_VERSION < "2.6.0" && file.match?(/_26.rb\Z/)
-    next if RUBY_VERSION < "2.7.0" && file.match?(/_27.rb\Z/)
     next if RUBY_VERSION < "3.0.0" && file.match?(/_30.rb\Z/)
 
     it "gives the same result for #{file}" do

--- a/test/ripper_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_parser/commenting_ripper_parser_test.rb
@@ -13,18 +13,6 @@ describe RipperParser::CommentingRipperParser do
   end
 
   describe "handling comments" do
-    # Handle different results for dynamic symbol strings. This was changed in
-    # Ruby 2.7.0, and backported to 2.6.3
-    #
-    # See https://bugs.ruby-lang.org/issues/15670
-    let(:dsym_string_type) do
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.3")
-        :string_content
-      else
-        :xstring
-      end
-    end
-
     it "produces a comment node surrounding a commented def" do
       result = parse_with_builder "# Foo\ndef foo; end"
       _(result).must_equal s(:program,
@@ -127,7 +115,7 @@ describe RipperParser::CommentingRipperParser do
       _(result).must_equal s(:program,
                              s(:stmts,
                                s(:dyna_symbol,
-                                 s(dsym_string_type,
+                                 s(:string_content,
                                    s(:@tstring_content, "foo", s(1, 2), ":'"))),
                                s(:comment,
                                  "",
@@ -144,7 +132,7 @@ describe RipperParser::CommentingRipperParser do
       _(result).must_equal s(:program,
                              s(:stmts,
                                s(:dyna_symbol,
-                                 s(dsym_string_type,
+                                 s(:string_content,
                                    s(:@tstring_content, "foo", s(1, 2), ':"'),
                                    s(:string_embexpr,
                                      s(:stmts,

--- a/test/ripper_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_parser/sexp_handlers/assignment_test.rb
@@ -252,22 +252,12 @@ describe RipperParser::Parser do
       end
 
       it "works with a rescue modifier" do
-        expected = if RUBY_VERSION < "2.7.0"
-                     s(:rescue,
-                       s(:masgn,
-                         s(:mlhs, s(:lvasgn, :foo), s(:lvasgn, :bar)),
-                         s(:send, nil, :baz)),
-                       s(:resbody, nil, nil, s(:send, nil, :qux)), nil)
-                   else
-                     s(:masgn,
-                       s(:mlhs, s(:lvasgn, :foo), s(:lvasgn, :bar)),
-                       s(:rescue,
-                         s(:send, nil, :baz),
-                         s(:resbody, nil, nil, s(:send, nil, :qux)), nil))
-                   end
-
         _("foo, bar = baz rescue qux")
-          .must_be_parsed_as expected
+          .must_be_parsed_as s(:masgn,
+                               s(:mlhs, s(:lvasgn, :foo), s(:lvasgn, :bar)),
+                               s(:rescue,
+                                 s(:send, nil, :baz),
+                                 s(:resbody, nil, nil, s(:send, nil, :qux)), nil))
       end
 
       it "works the same number of items on each side" do

--- a/test/ripper_parser/sexp_handlers/blocks_test.rb
+++ b/test/ripper_parser/sexp_handlers/blocks_test.rb
@@ -237,30 +237,12 @@ describe RipperParser::Parser do
       end
 
       it "works with numbered parameters" do
-        if RUBY_VERSION < "2.7.0"
-          skip "This Ruby version does not support numbered parameters"
-        end
         _("foo { bar _1, _2 }")
           .must_be_parsed_as s(:numblock,
                                s(:send, nil, :foo), 2,
                                s(:send, nil, :bar,
                                  s(:lvar, :_1),
                                  s(:lvar, :_2)))
-      end
-
-      it "parses code that looks like numbered parameters correctly on older rubies" do
-        if RUBY_VERSION >= "2.7.0"
-          skip "This Ruby version interprets this code as numbered parameters"
-        end
-        _("_1 = 1; foo { bar _1, _2 }")
-          .must_be_parsed_as s(:begin,
-                               s(:lvasgn, :_1, s(:int, 1)),
-                               s(:block,
-                                 s(:send, nil, :foo),
-                                 s(:args),
-                                 s(:send, nil, :bar,
-                                   s(:lvar, :_1),
-                                   s(:send, nil, :_2))))
       end
     end
 
@@ -757,30 +739,12 @@ describe RipperParser::Parser do
       end
 
       it "works with numbered parameters" do
-        if RUBY_VERSION < "2.7.0"
-          skip "This Ruby version does not support numbered parameters"
-        end
         _("-> { bar _1, _2 }").must_be_parsed_as \
           s(:numblock,
             s(:lambda), 2,
             s(:send, nil, :bar,
               s(:lvar, :_1),
               s(:lvar, :_2)))
-      end
-
-      it "parses code that looks like numbered parameters correctly on older rubies" do
-        if RUBY_VERSION >= "2.7.0"
-          skip "This Ruby version interprets this code as numbered parameters"
-        end
-        _("_1 = 1; -> { bar _1, _2 }")
-          .must_be_parsed_as s(:begin,
-                               s(:lvasgn, :_1, s(:int, 1)),
-                               s(:block,
-                                 s(:lambda),
-                                 s(:args),
-                                 s(:send, nil, :bar,
-                                   s(:lvar, :_1),
-                                   s(:send, nil, :_2))))
       end
 
       it "sets line numbers correctly for lambdas with empty bodies" do

--- a/test/ripper_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_parser/sexp_handlers/conditionals_test.rb
@@ -562,10 +562,6 @@ describe RipperParser::Parser do
     end
 
     describe "for a case block with in clauses" do
-      before do
-        skip "This Ruby version does not support pattern matching" if RUBY_VERSION < "2.7.0"
-      end
-
       it "works with a single in clause" do
         _("case foo; in bar; qux bar; end")
           .must_be_parsed_as s(:case_match,
@@ -642,10 +638,6 @@ describe RipperParser::Parser do
     end
 
     describe "for one-line pattern matching" do
-      before do
-        skip "This Ruby version does not support pattern matching" if RUBY_VERSION < "2.7.0"
-      end
-
       it "works for the simple case" do
         expected = if RUBY_VERSION < "3.0.0"
                      s(:match_pattern,

--- a/test/ripper_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_parser/sexp_handlers/methods_test.rb
@@ -230,9 +230,6 @@ describe RipperParser::Parser do
       end
 
       it "works with argument forwarding" do
-        if RUBY_VERSION < "2.7.0"
-          skip "This Ruby version does not support argument forwarding"
-        end
         _("def foo(...); bar(...); end")
           .must_be_parsed_as s(:def, :foo,
                                s(:args, s(:forward_arg)),
@@ -241,9 +238,6 @@ describe RipperParser::Parser do
       end
 
       it "works with argument forwarding with extra parameters" do
-        if RUBY_VERSION < "2.7.0"
-          skip "This Ruby version does not support argument forwarding"
-        end
         _("def foo(...); bar(baz, ...); end")
           .must_be_parsed_as s(:def, :foo,
                                s(:args, s(:forward_arg)),

--- a/test/ripper_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_parser/sexp_handlers/methods_test.rb
@@ -237,7 +237,12 @@ describe RipperParser::Parser do
                                  s(:forwarded_args)))
       end
 
-      it "works with argument forwarding with extra parameters" do
+      it "works with argument forwarding with leading call arguments" do
+        # Implemented in 3.0 and backported to 2.7.3.
+        # See https://bugs.ruby-lang.org/issues/16378
+        if RUBY_VERSION < "2.7.3"
+          skip "This Ruby version does not support this style of argument forwarding"
+        end
         _("def foo(...); bar(baz, ...); end")
           .must_be_parsed_as s(:def, :foo,
                                s(:args, s(:forward_arg)),
@@ -246,7 +251,9 @@ describe RipperParser::Parser do
       end
 
       it "works with argument forwarding with leading method arguments" do
-        if RUBY_VERSION < "3.0.0"
+        # Implemented in 3.0 and backported to 2.7.3.
+        # See https://bugs.ruby-lang.org/issues/16378
+        if RUBY_VERSION < "2.7.3"
           skip "This Ruby version does not support this style of argument forwarding"
         end
         _("def foo(bar, ...); baz(...); end")
@@ -258,7 +265,9 @@ describe RipperParser::Parser do
 
       it "works for multi-statement method body with argument forwarding" \
          " with leading method arguments" do
-        if RUBY_VERSION < "3.0.0"
+        # Implemented in 3.0 and backported to 2.7.3.
+        # See https://bugs.ruby-lang.org/issues/16378
+        if RUBY_VERSION < "2.7.3"
           skip "This Ruby version does not support this style of argument forwarding"
         end
         _("def foo(bar, ...); baz bar; qux(...); end")

--- a/test/ripper_parser/sexp_handlers/operators_test.rb
+++ b/test/ripper_parser/sexp_handlers/operators_test.rb
@@ -244,13 +244,11 @@ describe RipperParser::Parser do
       end
 
       it "handles endless range literals" do
-        skip "This Ruby version does not support endless ranges" if RUBY_VERSION < "2.6.0"
         _("1..")
           .must_be_parsed_as s(:irange, s(:int, 1), nil)
       end
 
       it "handles beginless range literals" do
-        skip "This Ruby version does not support beginless ranges" if RUBY_VERSION < "2.7.0"
         _("..1")
           .must_be_parsed_as s(:irange, nil, s(:int, 1))
       end
@@ -314,13 +312,11 @@ describe RipperParser::Parser do
       end
 
       it "handles endless range literals" do
-        skip "This Ruby version does not support endless ranges" if RUBY_VERSION < "2.6.0"
         _("1...")
           .must_be_parsed_as s(:erange, s(:int, 1), nil)
       end
 
       it "handles beginless range literals" do
-        skip "This Ruby version does not support beginless ranges" if RUBY_VERSION < "2.7.0"
         _("...1")
           .must_be_parsed_as s(:erange, nil, s(:int, 1))
       end

--- a/test/samples/ruby_27.rb
+++ b/test/samples/ruby_27.rb
@@ -8,7 +8,6 @@ foo = 2; # Extra ; needed here: https://github.com/whitequark/parser/issues/814
 # Argument forwarding
 def foo(...)
   bar(...)
-  bar(qux, ...)
 end
 
 # Pattern matching (experimental)

--- a/test/samples/ruby_30.rb
+++ b/test/samples/ruby_30.rb
@@ -9,10 +9,16 @@ case foo
   quz = bar + baz
 end
 
-# Argument forwarding with leading argument
+# Argument forwarding with leading argument in definition
 def foo(bar, ...)
   baz bar
   qux(...)
+end
+
+# Argument forwarding with leading argument in call
+def foo(...)
+  bar(...)
+  bar(qux, ...)
 end
 
 # Endless methods


### PR DESCRIPTION
- Drop support for Ruby 2.6
- Remove now-obsolete RUBY_VERSION check
- Remove obsolete version checks from tests
