### PR TITLE
Support Ruby 3.0 through 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7.0", "2.7.2", "2.7.3", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0.0", "3.0", "3.1", "3.2", "3.3"]
       fail-fast: false
 
     steps:
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
   Exclude:
     - 'test/samples/*'
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/lib/ripper_parser/commenting_ripper_parser.rb
+++ b/lib/ripper_parser/commenting_ripper_parser.rb
@@ -325,7 +325,8 @@ module RipperParser
     end
 
     def on_parse_error(message)
-      raise SyntaxError, message
+      super
+      raise SyntaxError, message if message.start_with?("syntax error,")
     end
 
     def on_class_name_error(message, *)

--- a/lib/ripper_parser/sexp_handlers/conditionals.rb
+++ b/lib/ripper_parser/sexp_handlers/conditionals.rb
@@ -60,11 +60,7 @@ module RipperParser
           first, *rest = process(clauses)
           _, pattern, _, truepart = first
           if truepart.nil?
-            if RUBY_VERSION < "3.0.0"
-              s(:match_pattern, expr, pattern)
-            else
-              s(:match_pattern_p, expr, pattern)
-            end
+            s(:match_pattern_p, expr, pattern)
           else
             s(:case_match, expr, first, *rest)
           end

--- a/lib/ripper_parser/sexp_handlers/string_literals.rb
+++ b/lib/ripper_parser/sexp_handlers/string_literals.rb
@@ -108,12 +108,12 @@ module RipperParser
         s(:symbols, *items)
       end
 
-      INTERPOLATING_HEREDOC = /^<<[-~]?[^-'~]/.freeze
-      NON_INTERPOLATING_HEREDOC = /^<<[-~]?'/.freeze
+      INTERPOLATING_HEREDOC = /^<<[-~]?[^-'~]/
+      NON_INTERPOLATING_HEREDOC = /^<<[-~]?'/
       INTERPOLATING_STRINGS = ['"', "`", ':"', /^%Q.$/, /^%.$/].freeze
       NON_INTERPOLATING_STRINGS = ["'", ":'", /^%q.$/].freeze
-      INTERPOLATING_WORD_LIST = /^%[WI].$/.freeze
-      NON_INTERPOLATING_WORD_LIST = /^%[wi].$/.freeze
+      INTERPOLATING_WORD_LIST = /^%[WI].$/
+      NON_INTERPOLATING_WORD_LIST = /^%[wi].$/
       REGEXP_LITERALS = ["/", /^%r.$/].freeze
 
       def process_at_tstring_content(exp)

--- a/lib/ripper_parser/unescape.rb
+++ b/lib/ripper_parser/unescape.rb
@@ -20,7 +20,7 @@ module RipperParser
         M-.                 | # meta
         \n                  | # line break
         .                     # other single character
-      )/x.freeze
+      )/x
 
     SINGLE_LETTER_ESCAPES = {
       "a" => "\a",
@@ -37,7 +37,7 @@ module RipperParser
     SINGLE_LETTER_ESCAPES_REGEXP =
       Regexp.new("^[#{SINGLE_LETTER_ESCAPES.keys.join}]$")
 
-    LINE_CONTINUATION_REGEXP = /\\(\n|.)/.freeze
+    LINE_CONTINUATION_REGEXP = /\\(\n|.)/
 
     DELIMITER_PAIRS = {
       "(" => "()",

--- a/ripper_parser.gemspec
+++ b/ripper_parser.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "http://www.github.com/mvz/ripper_parser"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ripper_parser"

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -6,7 +6,6 @@ describe "Using RipperParser and Parser" do
   make_my_diffs_pretty!
 
   Dir.glob(File.expand_path("../samples/*.rb", File.dirname(__FILE__))).each do |file|
-    next if RUBY_VERSION < "3.0.0" && file.match?(/_30.rb\Z/)
     next if RUBY_VERSION < "3.1.0" && file.match?(/_31.rb\Z/)
 
     it "gives the same result for #{file}" do

--- a/test/ripper_parser/commenting_ripper_parser_test.rb
+++ b/test/ripper_parser/commenting_ripper_parser_test.rb
@@ -175,7 +175,7 @@ describe RipperParser::CommentingRipperParser do
     end
   end
 
-  describe "handling syntax errors" do
+  describe "handling errors" do
     it "raises an error for an incomplete source" do
       _(proc {
         parse_with_builder "def foo"
@@ -216,6 +216,15 @@ describe RipperParser::CommentingRipperParser do
       _(proc {
         parse_with_builder "def foo(BAR); end"
       }).must_raise RipperParser::SyntaxError
+    end
+
+    it "records non-fatal errors" do
+      skip "No error is detected in this Ruby version" if RUBY_VERSION < "3.3.0"
+
+      builder = RipperParser::CommentingRipperParser.new "yield"
+      result = builder.parse
+      _(result).must_equal s(:program, s(:stmts, s(:yield0)))
+      _(builder.error).must_equal "Invalid yield"
     end
   end
 end

--- a/test/ripper_parser/sexp_handlers/assignment_test.rb
+++ b/test/ripper_parser/sexp_handlers/assignment_test.rb
@@ -592,12 +592,6 @@ describe RipperParser::Parser do
     end
 
     describe "for rightward assignment" do
-      before do
-        if RUBY_VERSION < "3.0.0"
-          skip "This Ruby version does not support rightward assignment"
-        end
-      end
-
       it "works for the simple case" do
         _("42 => foo")
           .must_be_parsed_as s(:match_pattern, s(:int, 42), s(:match_var, :foo))

--- a/test/ripper_parser/sexp_handlers/conditionals_test.rb
+++ b/test/ripper_parser/sexp_handlers/conditionals_test.rb
@@ -639,43 +639,21 @@ describe RipperParser::Parser do
 
     describe "for one-line pattern matching" do
       it "works for the simple case" do
-        expected = if RUBY_VERSION < "3.0.0"
-                     s(:match_pattern,
-                       s(:int, 1),
-                       s(:match_var, :foo))
-                   else
-                     s(:match_pattern_p,
-                       s(:int, 1),
-                       s(:match_var, :foo))
-                   end
-        _("1 in foo").must_be_parsed_as expected
+        _("1 in foo").must_be_parsed_as s(:match_pattern_p,
+                                          s(:int, 1),
+                                          s(:match_var, :foo))
       end
 
       it "works for secondary assignment of matched expression" do
-        expected = if RUBY_VERSION < "3.0.0"
-                     s(:match_pattern,
-                       s(:int, 1),
-                       s(:match_as,
-                         s(:match_var, :foo),
-                         s(:match_var, :bar)))
-                   else
-                     s(:match_pattern_p,
-                       s(:int, 1),
-                       s(:match_as,
-                         s(:match_var, :foo),
-                         s(:match_var, :bar)))
-                   end
-        _("1 in foo => bar").must_be_parsed_as expected
+        _("1 in foo => bar").must_be_parsed_as s(:match_pattern_p,
+                                                 s(:int, 1),
+                                                 s(:match_as,
+                                                   s(:match_var, :foo),
+                                                   s(:match_var, :bar)))
       end
     end
 
     describe "for rightward assignment" do
-      before do
-        if RUBY_VERSION < "3.0.0"
-          skip "This Ruby version does not support rightward assignment"
-        end
-      end
-
       it "works for the simple case" do
         _("1 => foo")
           .must_be_parsed_as s(:match_pattern,

--- a/test/ripper_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_parser/sexp_handlers/methods_test.rb
@@ -249,11 +249,6 @@ describe RipperParser::Parser do
       end
 
       it "works with argument forwarding with leading call arguments" do
-        # Implemented in 3.0 and backported to 2.7.3.
-        # See https://bugs.ruby-lang.org/issues/16378
-        if RUBY_VERSION < "2.7.3"
-          skip "This Ruby version does not support this style of argument forwarding"
-        end
         _("def foo(...); bar(baz, ...); end")
           .must_be_parsed_as s(:def, :foo,
                                s(:args, s(:forward_arg)),
@@ -262,11 +257,6 @@ describe RipperParser::Parser do
       end
 
       it "works with argument forwarding with leading method arguments" do
-        # Implemented in 3.0 and backported to 2.7.3.
-        # See https://bugs.ruby-lang.org/issues/16378
-        if RUBY_VERSION < "2.7.3"
-          skip "This Ruby version does not support this style of argument forwarding"
-        end
         _("def foo(bar, ...); baz(...); end")
           .must_be_parsed_as s(:def, :foo,
                                s(:args, s(:arg, :bar), s(:forward_arg)),
@@ -276,11 +266,6 @@ describe RipperParser::Parser do
 
       it "works for multi-statement method body with argument forwarding" \
          " with leading method arguments" do
-        # Implemented in 3.0 and backported to 2.7.3.
-        # See https://bugs.ruby-lang.org/issues/16378
-        if RUBY_VERSION < "2.7.3"
-          skip "This Ruby version does not support this style of argument forwarding"
-        end
         _("def foo(bar, ...); baz bar; qux(...); end")
           .must_be_parsed_as s(:def, :foo,
                                s(:args, s(:arg, :bar), s(:forward_arg)),
@@ -310,10 +295,6 @@ describe RipperParser::Parser do
     end
 
     describe "for endless instance method definitions" do
-      before do
-        skip "This Ruby version does not support endless methods" if RUBY_VERSION < "3.0.0"
-      end
-
       it "works for a method with simple arguments" do
         _("def foo(bar) = baz(bar)")
           .must_be_parsed_as s(:def, :foo,
@@ -383,10 +364,6 @@ describe RipperParser::Parser do
     end
 
     describe "for endless singleton method definitions" do
-      before do
-        skip "This Ruby version does not support endless methods" if RUBY_VERSION < "3.0.0"
-      end
-
       it "works for a method with simple arguments" do
         _("def self.foo(bar) = baz(bar)")
           .must_be_parsed_as s(:defs,


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
- Drop obsolete RUBY_VERSION checks
- Autocorrect Style/RedundantFreeze
- Only raise SyntaxError if Ripper error is really a syntax error