### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0.0", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1.0", "3.1", "3.2", "3.3", "3.4"]
       fail-fast: false
 
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
   Exclude:
     - 'test/samples/*'
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/ripper_parser.gemspec
+++ b/ripper_parser.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
     to be a drop-in replacement for Parser.
   DESC
   spec.homepage = "http://www.github.com/mvz/ripper_parser"
+
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/ripper_parser"

--- a/test/end_to_end/samples_comparison_test.rb
+++ b/test/end_to_end/samples_comparison_test.rb
@@ -6,8 +6,6 @@ describe "Using RipperParser and Parser" do
   make_my_diffs_pretty!
 
   Dir.glob(File.expand_path("../samples/*.rb", File.dirname(__FILE__))).each do |file|
-    next if RUBY_VERSION < "3.1.0" && file.match?(/_31.rb\Z/)
-
     it "gives the same result for #{file}" do
       program = File.read file
       _(program).must_be_parsed_as_before

--- a/test/ripper_parser/sexp_handlers/literals_test.rb
+++ b/test/ripper_parser/sexp_handlers/literals_test.rb
@@ -119,9 +119,6 @@ describe RipperParser::Parser do
       end
 
       it "works for shorthand hash syntax" do
-        if RUBY_VERSION < "3.1.0"
-          skip "This Ruby version does not support shorthand hash syntax"
-        end
         _("{ foo: }")
           .must_be_parsed_as s(:hash, s(:pair, s(:sym, :foo), s(:lvar, :foo)))
       end

--- a/test/ripper_parser/sexp_handlers/methods_test.rb
+++ b/test/ripper_parser/sexp_handlers/methods_test.rb
@@ -139,9 +139,6 @@ describe RipperParser::Parser do
       end
 
       it "works for a bare block parameter" do
-        if RUBY_VERSION < "3.1.0"
-          skip "This Ruby version does not support bare block parameters"
-        end
         _("def foo &; end")
           .must_be_parsed_as s(:def,
                                :foo,
@@ -318,7 +315,6 @@ describe RipperParser::Parser do
       end
 
       it "works when the body calls a method without parentheses" do
-        skip "This Ruby version does not support this syntax" if RUBY_VERSION < "3.1.0"
         _("def foo = bar 42")
           .must_be_parsed_as s(:def, :foo, s(:args), s(:send, nil, :bar, s(:int, 42)))
       end


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
